### PR TITLE
add .gitlab-ci.yml example

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,21 @@
+# Select docker image from https://hub.docker.com/_/php/
+image: php:5.6
+
+# Use the current stable version of Dokuwiki for the unit test
+variables:
+  DOKUWIKI: "stable"
+
+before_script:
+# Install git, the php image doesn't have installed
+  - apt-get update -yqq
+  - apt-get install git -yqq
+# Install other missing utilities
+  - apt-get install wget -yqq
+  - apt-get install phpunit -yqq
+# Setup a raw dokuwiki install
+  - wget https://raw.github.com/splitbrain/dokuwiki-travis/master/travis.sh
+  - sh travis.sh
+
+runtest:
+  script: 
+    - cd _test && phpunit --stderr --group plugin_something


### PR DESCRIPTION
I added a .gitlab-ci.yml file as an example for GitLab users, which is running with the shared ci-runners on Gitlab.com.

It took me a few hours to figure out the required changes, so maybe this can save others some time...