### PR TITLE
Align travis.sh with fetchphpunit.php regarding PHP 7.4

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -73,7 +73,8 @@ if [ "$PHPV" = "5.6" ]; then
 elif [ "$PHPV" = "7.0" ]; then
     PHPUNIT='phpunit-6.phar'
 elif [ "$PHPV" = "7.4" ]; then
-    PHPUNIT='phpunit-8.phar'
+    # PHP 5 backward compatibility lock to PHPUnit 7 (type hinting)
+    PHPUNIT='phpunit-7.phar'
 else
     PHPUNIT='phpunit-7.phar'
 fi


### PR DESCRIPTION
Right now it would download PHPUnit 8 and thus fail due to type hint mismatches with DokuWiki test classes.